### PR TITLE
return the size of the remained blocking queue for monitoring

### DIFF
--- a/src/main/java/com/leansoft/luxun/producer/async/AsyncProducer.java
+++ b/src/main/java/com/leansoft/luxun/producer/async/AsyncProducer.java
@@ -133,7 +133,7 @@ public class AsyncProducer<T> implements Closeable {
     		throw new AsyncProducerInterruptedException(e);
     	}
     	if (this.callbackHandler != null) {
-    		this.callbackHandler.afterEnqueue(data, added);
+    		this.callbackHandler.afterEnqueue(data, queue.size(), added);
     	}
     	if (!added) {
     		AsyncProducerStats.recordDroppedEvents();

--- a/src/main/java/com/leansoft/luxun/producer/async/CallbackHandler.java
+++ b/src/main/java/com/leansoft/luxun/producer/async/CallbackHandler.java
@@ -52,10 +52,11 @@ public interface CallbackHandler<T> {
      * queue of the asynchronous producer
      * 
      * @param data the data sent to the producer
+     * @param remainSize the size of the remained data in blocking queue
      * @param added flag that indicates if the data was successfully added
      *        to the queue
      */
-    QueueItem<T> afterEnqueue(QueueItem<T> data, boolean added);
+    QueueItem<T> afterEnqueue(QueueItem<T> data, int remainSize, boolean added);
 
     /**
      * Callback to process the data item right after it has been dequeued


### PR DESCRIPTION
return the size of the remained blocking queue in AsyncProducer using callback for monitor. 
