### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-##_DISCLAIMER_
+## _DISCLAIMER_
 #### This project is still under construction. Beta testers are more than welcome.
 
 # Luxun
@@ -40,7 +40,7 @@ Luxun is based on the [bigqueue](https://github.com/bulldog2011/bigqueue) librar
 6. [Luxun - A Persistent Messaging System Tailored for Big Data Collecting & Analytics(ppt)](http://www.slideshare.net/yang75108/luxun)
 
 
-##Copyright and License
+## Copyright and License
 Copyright 2012 Leansoft Technology <51startup@sina.com>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License in the LICENSE file, or at:
@@ -49,7 +49,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-##Credits
+## Credits
 Luxun borrowed design ideas and adapted source from following open source projects:
 
 1. [Apache Kafka](http://kafka.apache.org/index.html), a distributed publish-subscribe messaging system using Scala as implementation language.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
